### PR TITLE
poetryがOpenAI whisperのダウンロード先として元のGitHubではなくPyPiを参照するようにする

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3047,8 +3047,10 @@ version = "0.0.7.2"
 description = "🍵 Matcha-TTS: A fast TTS architecture with conditional flow matching"
 optional = false
 python-versions = ">=3.9.0"
-files = []
-develop = false
+files = [
+    {file = "matcha-tts-0.0.7.2.tar.gz", hash = "sha256:86af5e36343fe742cbaea04020ddb0d55fc787ee7cd6c251c471e84babcd20f1"},
+    {file = "matcha_tts-0.0.7.2-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:47dc5c4dbdb270bc26af06a3404e89cc3c8cd11e58572975fe0ad1259b6db219"},
+]
 
 [package.dependencies]
 conformer = "0.3.2"
@@ -3082,12 +3084,6 @@ torchmetrics = ">=0.11.4"
 torchvision = ">=0.15.0"
 Unidecode = "*"
 wget = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/shivammehta25/Matcha-TTS"
-reference = "main"
-resolved_reference = "108906c603fad5055f2649b3fd71d2bbdf222eac"
 
 [[package]]
 name = "matplotlib"
@@ -7639,4 +7635,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.9"
-content-hash = "6bce5ba91e324ac23596c9908d7777854082bc06152e0d9452d1dac5a88a62a1"
+content-hash = "bfc45dfc40fd4856079b891564a83fc0fe0389f7a1a99c69bcc2c23f8f1dfcba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ WeTextProcessing = "*"
 wget = "3.2"
 tqdm = "^4.67.1"
 openai-whisper = "*"
-matcha-tts = {git = "https://github.com/shivammehta25/Matcha-TTS", rev = "main"}
+matcha-tts = "*"
 tensorrt-cu12 = {version = "*", platform = "linux", source = "tensorrt-cu12"}
 tensorrt-cu12-bindings = {version = "*", platform = "linux", source = "tensorrt-cu12"}
 tensorrt-cu12-libs = {version = "*", platform = "linux", source = "tensorrt-cu12"}


### PR DESCRIPTION
## なぜこの変更が必要で何を変更したのか（why & what）
- 下記でlucasadmin側でwhisperのインストールに失敗している話が言及されている。
  - https://mixigroup.slack.com/archives/CTTBVATM1/p1752643640531149?thread_ts=1752547911.469949&cid=CTTBVATM1
- 直接的な原因がGitHubを直接参照していることなのかどうかは実際定かではないのだが、上記のやり取りにて提示されたログから関係を怪しんでおり、尚且つPyPiでも最新バージョンのWhisperは使用可能なので、Whisperの参照先をPyPiに変える
※以下、追記
- コメントでの指摘により、Matcha-TTSもPyPiを参照するように修正した。こちらもWhisper同様にPyPiで管理されているバージョンがGitHubで公開されているものに追いついており、尚且つ、下記のコメントで記載した通りe2e側の動作検証も問題なくできている。

## どのように実現するのか（how）
- 念の為、e2e側のCosyVoiceレポジトリの参照先を本PR用のブランチに向けた上で、下記に記載したような動作検証を実施した。
<details>

<summary>動作検証時のログ</summary>

```sh
ip-172-31-24-122 :: ~/shota.tanemura/e2e ‹update-cosyvoice2-for-its-dependencies-changes*› » docker run --env SERVER_MODE=japanese -it --gpus all -p 10080:10080 -v ${PWD}:/app 921916953396.dkr.ecr.ap-northeast-1.amazonaws.com/pjlucas/cuda:1.21-cuda12.8.0-devel-ubuntu22.04 poetry run python -m "e2e.model.tts.cosyvoice
2"
INFO 07-16 15:00:18 [__init__.py:244] Automatically detected platform cuda.
failed to import ttsfrd, use WeTextProcessing instead
2025-07-16 15:00:25,645 DEBUG Using selector: EpollSelector
time:2025-07-16 15:00:25.647+09:00	pid:1	module:utilucas.cloud_backend	line:33	level:WARNING	reqid:global	body:環境の特定に失敗しました。
time:2025-07-16 15:00:25.685+09:00	pid:1	module:utilucas.requestcontext.request_lifecycle_manager	line:87	level:INFO	reqid:e2e-ZwA73Zpg    	body:enter request context. type: ScriptRequestContext id: e2e-ZwA73Zpg
time:2025-07-16 15:00:25.685+09:00	pid:1	module:utilucas.script_runner	line:87	level:INFO	reqid:e2e-ZwA73Zpg	body:script_runner context start.
time:2025-07-16 15:00:25.695+09:00	pid:1	module:__main__	line:95	level:INFO	reqid:e2e-ZwA73Zpg	body:CosyVoice2TTS base path: s3://lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1
time:2025-07-16 15:00:25.695+09:00	pid:1	module:__main__	line:99	level:INFO	reqid:e2e-ZwA73Zpg	body:CosyVoice2TTS model folder path: s3://lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/CosyVoice2-0.5B
time:2025-07-16 15:00:26.733+09:00	pid:1	module:botocore.credentials	line:1132	level:INFO	reqid:e2e-ZwA73Zpg	body:Found credentials from IAM Role: developer
time:2025-07-16 15:00:27.344+09:00	pid:1	module:__main__	line:124	level:INFO	reqid:e2e-ZwA73Zpg	body:Downloading 26 objects from s3://lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/CosyVoice2-0.5B
time:2025-07-16 15:00:27.351+09:00	pid:1	module:__main__	line:104	level:INFO	reqid:e2e-ZwA73Zpg	body:CosyVoice2TTS asset folder path: s3://lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset
time:2025-07-16 15:00:27.406+09:00	pid:1	module:__main__	line:124	level:INFO	reqid:e2e-ZwA73Zpg	body:Downloading 137 objects from s3://lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset
time:2025-07-16 15:00:27.650+09:00	pid:1	module:utilucas.metrics	line:120	level:INFO	reqid:e2e-ZwA73Zpg	body:elapsed time of download_tts_model: 1.9642810821533203 sec
/app/.venv/lib/python3.11/site-packages/lightning/fabric/__init__.py:41: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
/app/.venv/lib/python3.11/site-packages/diffusers/models/lora.py:393: FutureWarning: `LoRACompatibleLinear` is deprecated and will be removed in version 1.0.0. Use of `LoRACompatibleLinear` is deprecated. Please switch to PEFT backend by installing PEFT: `pip install peft`.
  deprecate("LoRACompatibleLinear", "1.0.0", deprecation_message)
time:2025-07-16 15:00:35.768+09:00	pid:1	module:root	line:179	level:INFO	reqid:e2e-ZwA73Zpg	body:input frame rate=25
/app/.venv/lib/python3.11/site-packages/torch/nn/utils/weight_norm.py:143: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.
  WeightNorm.apply(module, name, dim)
2025-07-16 15:00:40.012069953 [W:onnxruntime:, transformer_memcpy.cc:83 ApplyImpl] 8 Memcpy nodes are added to the graph main_graph for CUDAExecutionProvider. It might have negative impact on performance (including unable to run CUDA graph). Set session_options.log_severity_level=1 to see the detail logs before this message.
2025-07-16 15:00:40.015336521 [W:onnxruntime:, session_state.cc:1280 VerifyEachNodeIsAssignedToAnEp] Some nodes were not assigned to the preferred execution providers which may or may not have an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.
2025-07-16 15:00:40.015357431 [W:onnxruntime:, session_state.cc:1282 VerifyEachNodeIsAssignedToAnEp] Rerunning with verbose output on a non-minimal build will show node assignments.
2025-07-16 15:00:40,277 WETEXT INFO found existing fst: /app/.venv/lib/python3.11/site-packages/tn/zh_tn_tagger.fst
time:2025-07-16 15:00:40.277+09:00	pid:1	module:wetext-zh_normalizer	line:95	level:INFO	reqid:e2e-ZwA73Zpg	body:found existing fst: /app/.venv/lib/python3.11/site-packages/tn/zh_tn_tagger.fst
2025-07-16 15:00:40,277 WETEXT INFO                     /app/.venv/lib/python3.11/site-packages/tn/zh_tn_verbalizer.fst
time:2025-07-16 15:00:40.277+09:00	pid:1	module:wetext-zh_normalizer	line:96	level:INFO	reqid:e2e-ZwA73Zpg	body:                    /app/.venv/lib/python3.11/site-packages/tn/zh_tn_verbalizer.fst
2025-07-16 15:00:40,278 WETEXT INFO skip building fst for zh_normalizer ...
time:2025-07-16 15:00:40.278+09:00	pid:1	module:wetext-zh_normalizer	line:97	level:INFO	reqid:e2e-ZwA73Zpg	body:skip building fst for zh_normalizer ...
2025-07-16 15:00:40,612 WETEXT INFO found existing fst: /app/.venv/lib/python3.11/site-packages/tn/en_tn_tagger.fst
time:2025-07-16 15:00:40.612+09:00	pid:1	module:wetext-en_normalizer	line:95	level:INFO	reqid:e2e-ZwA73Zpg	body:found existing fst: /app/.venv/lib/python3.11/site-packages/tn/en_tn_tagger.fst
2025-07-16 15:00:40,612 WETEXT INFO                     /app/.venv/lib/python3.11/site-packages/tn/en_tn_verbalizer.fst
time:2025-07-16 15:00:40.612+09:00	pid:1	module:wetext-en_normalizer	line:96	level:INFO	reqid:e2e-ZwA73Zpg	body:                    /app/.venv/lib/python3.11/site-packages/tn/en_tn_verbalizer.fst
2025-07-16 15:00:40,612 WETEXT INFO skip building fst for en_normalizer ...
time:2025-07-16 15:00:40.612+09:00	pid:1	module:wetext-en_normalizer	line:97	level:INFO	reqid:e2e-ZwA73Zpg	body:skip building fst for en_normalizer ...
INFO 07-16 15:00:55 [config.py:841] This model supports multiple tasks: {'embed', 'generate', 'classify', 'reward'}. Defaulting to 'generate'.
INFO 07-16 15:00:55 [config.py:1472] Using max model len 32768
WARNING 07-16 15:00:55 [arg_utils.py:1735] --enable-prompt-embeds is not supported by the V1 Engine. Falling back to V0.
INFO 07-16 15:00:55 [llm_engine.py:230] Initializing a V0 LLM engine (v0.9.2) with config: model='tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/CosyVoice2-0.5B/vllm', speculative_config=None, tokenizer='tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/CosyVoice2-0.5B/vllm', skip_tokenizer_init=True, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/CosyVoice2-0.5B/vllm, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=None, chunked_prefill_enabled=False, use_async_output_proc=True, pooler_config=None, compilation_config={"level":0,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":[],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"use_cudagraph":true,"cudagraph_num_of_warmups":0,"cudagraph_capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"max_capture_size":256,"local_cache_dir":null}, use_cached_outputs=False,
INFO 07-16 15:00:55 [cuda.py:363] Using Flash Attention backend.
INFO 07-16 15:00:56 [parallel_state.py:1076] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
INFO 07-16 15:00:56 [model_runner.py:1171] Starting to load model tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/CosyVoice2-0.5B/vllm...
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:05<00:00,  6.00s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:05<00:00,  6.00s/it]

INFO 07-16 15:01:02 [default_loader.py:272] Loading weights took 6.06 seconds
INFO 07-16 15:01:03 [model_runner.py:1203] Model loading took 0.6951 GiB and 6.265506 seconds
INFO 07-16 15:01:04 [worker.py:294] Memory profiling takes 1.07 seconds
INFO 07-16 15:01:04 [worker.py:294] the current vLLM instance can use total_gpu_memory (22.06GiB) x gpu_memory_utilization (0.50) = 11.03GiB
INFO 07-16 15:01:04 [worker.py:294] model weights take 0.70GiB; non_torch_memory takes 0.05GiB; PyTorch activation peak memory takes 1.12GiB; the rest of the memory reserved for KV Cache is 9.16GiB.
INFO 07-16 15:01:05 [executor_base.py:113] # cuda blocks: 50043, # CPU blocks: 21845
INFO 07-16 15:01:05 [executor_base.py:118] Maximum concurrency for 32768 tokens per request: 24.44x
INFO 07-16 15:01:10 [model_runner.py:1513] Capturing cudagraphs for decoding. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI. If out-of-memory error occurs during cudagraph capture, consider decreasing `gpu_memory_utilization` or switching to eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
Capturing CUDA graph shapes: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 70/70 [00:44<00:00,  1.56it/s]
INFO 07-16 15:01:55 [model_runner.py:1671] Graph capturing finished in 45 secs, took 0.26 GiB
INFO 07-16 15:01:55 [llm_engine.py:428] init engine (profile, create kv cache, warmup model) took 52.05 seconds
time:2025-07-16 15:01:57.298+09:00	pid:1	module:utilucas.metrics	line:120	level:INFO	reqid:e2e-ZwA73Zpg	body:elapsed time of load_tts_model: 89.64769244194031 sec
time:2025-07-16 15:01:57.299+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_C/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_C/angry/takami_ikari_01.wav
time:2025-07-16 15:01:57.404+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_C/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_C/fear/takami_kyofu_04.wav
time:2025-07-16 15:01:57.414+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_C/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_C/happy/takami_yorokobi_04.wav
time:2025-07-16 15:01:57.423+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_C/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_C/normal/takami_normal_03.wav
time:2025-07-16 15:01:57.438+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_C/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_C/relax/takami_relax_03.wav
time:2025-07-16 15:01:57.446+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_C/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_C/sad/takami_kanashimi_03.wav
time:2025-07-16 15:01:57.463+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_C/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_C/surprise/takami_odoroki_10.wav
time:2025-07-16 15:01:57.478+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_D/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_D/angry/F_child_character_D_angry_9.wav
time:2025-07-16 15:01:57.487+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_D/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_D/fear/F_child_character_D_fear_1.wav
time:2025-07-16 15:01:57.495+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_D/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_D/happy/F_child_character_D_happy_10.wav
time:2025-07-16 15:01:57.504+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_D/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_D/normal/F_child_character_D_normal_10.wav
time:2025-07-16 15:01:57.519+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_D/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_D/relax/F_child_character_D_relax_2.wav
time:2025-07-16 15:01:57.538+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_D/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_D/sad/F_child_character_D_sad_5.wav
time:2025-07-16 15:01:57.547+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_D/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_D/surprise/F_child_character_D_surprise_5.wav
time:2025-07-16 15:01:57.554+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_B/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_B/angry/F_natural_B_angry_10.wav
time:2025-07-16 15:01:57.561+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_B/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_B/fear/F_natural_B_fear_1.wav
time:2025-07-16 15:01:57.569+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_B/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_B/happy/F_natural_B_happy_10.wav
time:2025-07-16 15:01:57.577+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_B/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_B/normal/F_natural_B_normal_6.wav
time:2025-07-16 15:01:57.585+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_B/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_B/relax/F_natural_B_relax_8.wav
time:2025-07-16 15:01:57.594+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_B/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_B/sad/F_natural_B_sad_9.wav
time:2025-07-16 15:01:57.603+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_B/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_B/surprise/F_natural_B_surprise_3.wav
time:2025-07-16 15:01:57.610+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_A/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_A/angry/F_natural_A_angry_10.wav
time:2025-07-16 15:01:57.620+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_A/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_A/fear/F_natural_A_fear_1.wav
time:2025-07-16 15:01:57.628+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_A/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_A/happy/F_natural_A_happy_10.wav
time:2025-07-16 15:01:57.636+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_A/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_A/normal/F_natural_A_normal_6.wav
time:2025-07-16 15:01:57.648+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_A/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_A/relax/F_natural_A_relax_6.wav
time:2025-07-16 15:01:57.661+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_A/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_A/sad/F_natural_A_sad_9.wav
time:2025-07-16 15:01:57.671+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_A/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_A/surprise/F_natural_A_surprise_3.wav
time:2025-07-16 15:01:57.684+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_actress/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_actress/angry/F_actress_angry_10.wav
time:2025-07-16 15:01:57.691+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_actress/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_actress/fear/F_actress_fear_1.wav
time:2025-07-16 15:01:57.702+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_actress/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_actress/happy/F_actress_happy_11.wav
time:2025-07-16 15:01:57.711+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_actress/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_actress/normal/F_actress_normal_14.wav
time:2025-07-16 15:01:57.723+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_actress/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_actress/relax/F_actress_relax_6.wav
time:2025-07-16 15:01:57.733+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_actress/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_actress/sad/F_actress_sad_7.wav
time:2025-07-16 15:01:57.746+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_actress/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_actress/surprise/F_actress_surprise_3.wav
time:2025-07-16 15:01:57.759+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_shibui/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_shibui/angry/M_shibui_angry_9.wav
time:2025-07-16 15:01:57.766+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_shibui/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_shibui/fear/M_shibui_fear_1.wav
time:2025-07-16 15:01:57.774+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_shibui/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_shibui/happy/M_shibui_happy_4.wav
time:2025-07-16 15:01:57.783+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_shibui/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_shibui/normal/M_shibui_normal_3.wav
time:2025-07-16 15:01:57.792+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_shibui/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_shibui/relax/M_shibui_relax_12.wav
time:2025-07-16 15:01:57.802+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_shibui/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_shibui/sad/M_shibui_sad_11.wav
time:2025-07-16 15:01:57.813+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_shibui/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_shibui/surprise/M_shibui_surprise_3.wav
time:2025-07-16 15:01:57.820+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_B/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_B/angry/F_husky_B_angry_10.wav
time:2025-07-16 15:01:57.828+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_B/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_B/fear/F_husky_B_fear_13.wav
time:2025-07-16 15:01:57.837+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_B/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_B/happy/F_husky_B_happy_9.wav
time:2025-07-16 15:01:57.847+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_B/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_B/normal/F_husky_B_normal_2.wav
time:2025-07-16 15:01:57.855+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_B/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_B/relax/F_husky_B_relax_9.wav
time:2025-07-16 15:01:57.864+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_B/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_B/sad/F_husky_B_sad_13.wav
time:2025-07-16 15:01:57.875+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_B/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_B/surprise/F_husky_B_surprise_3.wav
time:2025-07-16 15:01:57.883+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_C/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_C/angry/向坂_angry_1.wav
time:2025-07-16 15:01:57.894+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_C/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_C/fear/向坂_fear_10.wav
time:2025-07-16 15:01:57.902+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_C/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_C/happy/向坂_happy_9.wav
time:2025-07-16 15:01:57.911+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_C/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_C/normal/向坂_normal_2.wav
time:2025-07-16 15:01:57.918+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_C/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_C/relax/向坂_relax_2.wav
time:2025-07-16 15:01:57.926+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_C/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_C/sad/向坂_sad_10.wav
time:2025-07-16 15:01:57.936+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_natural_C/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_natural_C/surprise/向坂_surprise_3.wav
time:2025-07-16 15:01:57.947+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_A/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_A/angry/F_child_character_A_angry_1.wav
time:2025-07-16 15:01:57.955+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_A/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_A/fear/F_child_character_A_fear_11.wav
time:2025-07-16 15:01:57.964+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_A/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_A/happy/F_child_character_A_happy_1.wav
time:2025-07-16 15:01:57.973+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_A/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_A/normal/F_child_character_A_normal_3.wav
time:2025-07-16 15:01:57.982+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_A/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_A/relax/F_child_character_A_relax_9.wav
time:2025-07-16 15:01:57.991+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_A/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_A/sad/F_child_character_A_sad_11.wav
time:2025-07-16 15:01:58.002+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_A/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_A/surprise/F_child_character_A_surprise_3.wav
time:2025-07-16 15:01:58.009+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_A/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_A/angry/F_child_A_angry_1.wav
time:2025-07-16 15:01:58.017+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_A/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_A/fear/F_child_A_fear_7.wav
time:2025-07-16 15:01:58.027+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_A/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_A/happy/F_child_A_happy_5.wav
time:2025-07-16 15:01:58.037+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_A/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_A/normal/F_child_A_normal_3.wav
time:2025-07-16 15:01:58.049+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_A/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_A/relax/F_child_A_relax_10.wav
time:2025-07-16 15:01:58.065+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_A/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_A/sad/F_child_A_sad_2.wav
time:2025-07-16 15:01:58.079+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_A/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_A/surprise/F_child_A_surprise_4.wav
time:2025-07-16 15:01:58.092+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_A/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_A/angry/F_husky_A_angry_13.wav
time:2025-07-16 15:01:58.105+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_A/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_A/fear/F_husky_A_fear_4.wav
time:2025-07-16 15:01:58.115+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_A/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_A/happy/F_husky_A_happy_13.wav
time:2025-07-16 15:01:58.130+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_A/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_A/normal/F_husky_A_normal_6.wav
time:2025-07-16 15:01:58.144+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_A/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_A/relax/F_husky_A_relax_6.wav
time:2025-07-16 15:01:58.160+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_A/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_A/sad/F_husky_A_sad_12.wav
time:2025-07-16 15:01:58.179+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_husky_A/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_husky_A/surprise/F_husky_A_surprise_3.wav
time:2025-07-16 15:01:58.191+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_C/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_C/angry/F_child_character_C_angry_9.wav
time:2025-07-16 15:01:58.200+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_C/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_C/fear/F_child_character_C_fear_4.wav
time:2025-07-16 15:01:58.209+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_C/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_C/happy/F_child_character_C_happy_10.wav
time:2025-07-16 15:01:58.223+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_C/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_C/normal/F_child_character_C_normal_8.wav
time:2025-07-16 15:01:58.235+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_C/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_C/relax/F_child_character_C_relax_8.wav
time:2025-07-16 15:01:58.244+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_C/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_C/sad/F_child_character_C_sad_10.wav
time:2025-07-16 15:01:58.261+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_C/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_C/surprise/F_child_character_C_surprise_3.wav
time:2025-07-16 15:01:58.268+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_B/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_B/angry/F_child_B_angry_8.wav
time:2025-07-16 15:01:58.278+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_B/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_B/fear/F_child_B_fear_1.wav
time:2025-07-16 15:01:58.287+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_B/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_B/happy/F_child_B_happy_5.wav
time:2025-07-16 15:01:58.297+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_B/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_B/normal/F_child_B_normal_3.wav
time:2025-07-16 15:01:58.308+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_B/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_B/relax/F_child_B_relax_6.wav
time:2025-07-16 15:01:58.322+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_B/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_B/sad/F_child_B_sad_2.wav
time:2025-07-16 15:01:58.332+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_B/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_B/surprise/F_child_B_surprise_4.wav
time:2025-07-16 15:01:58.342+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_B/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_B/angry/M_iyashi_B_angry_9.wav
time:2025-07-16 15:01:58.354+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_B/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_B/fear/M_iyashi_B_fear_4.wav
time:2025-07-16 15:01:58.363+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_B/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_B/happy/M_iyashi_B_happy_10.wav
time:2025-07-16 15:01:58.371+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_B/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_B/normal/M_iyashi_B_normal_3.wav
time:2025-07-16 15:01:58.380+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_B/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_B/relax/M_iyashi_B_relax_5.wav
time:2025-07-16 15:01:58.389+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_B/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_B/sad/M_iyashi_B_sad_10.wav
time:2025-07-16 15:01:58.408+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_B/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_B/surprise/M_iyashi_B_surprise_3.wav
time:2025-07-16 15:01:58.420+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_B/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_B/angry/M_ikevo_B_angry_9.wav
time:2025-07-16 15:01:58.434+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_B/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_B/fear/M_ikevo_B_fear_10.wav
time:2025-07-16 15:01:58.440+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_B/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_B/happy/M_ikevo_B_happy_10.wav
time:2025-07-16 15:01:58.448+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_B/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_B/normal/M_ikevo_B_normal_14.wav
time:2025-07-16 15:01:58.456+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_B/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_B/relax/M_ikevo_B_relax_1.wav
time:2025-07-16 15:01:58.471+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_B/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_B/sad/M_ikevo_B_sad_17.wav
time:2025-07-16 15:01:58.482+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_B/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_B/surprise/M_ikevo_B_surprise_3.wav
time:2025-07-16 15:01:58.493+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_B/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_B/angry/F_child_character_B_angry_9.wav
time:2025-07-16 15:01:58.502+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_B/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_B/fear/F_child_character_B_fear_9.wav
time:2025-07-16 15:01:58.510+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_B/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_B/happy/F_child_character_B_happy_10.wav
time:2025-07-16 15:01:58.518+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_B/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_B/normal/F_child_character_B_normal_11.wav
time:2025-07-16 15:01:58.528+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_B/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_B/relax/F_child_character_B_relax_5.wav
time:2025-07-16 15:01:58.539+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_B/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_B/sad/F_child_character_B_sad_10.wav
time:2025-07-16 15:01:58.552+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: F_child_character_B/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/F_child_character_B/surprise/F_child_character_B_surprise_3.wav
time:2025-07-16 15:01:58.560+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_A/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_A/angry/M_iyashi_A_angry_9.wav
time:2025-07-16 15:01:58.567+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_A/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_A/fear/M_iyashi_A_fear_9.wav
time:2025-07-16 15:01:58.574+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_A/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_A/happy/M_iyashi_A_happy_10.wav
time:2025-07-16 15:01:58.586+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_A/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_A/normal/M_iyashi_A_normal_6.wav
time:2025-07-16 15:01:58.593+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_A/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_A/relax/M_iyashi_A_relax_5.wav
time:2025-07-16 15:01:58.600+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_A/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_A/sad/M_iyashi_A_sad_10.wav
time:2025-07-16 15:01:58.608+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_iyashi_A/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_iyashi_A/surprise/M_iyashi_A_surprise_5.wav
time:2025-07-16 15:01:58.618+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_A/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_A/angry/M_ikevo_A_angry_2.wav
time:2025-07-16 15:01:58.630+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_A/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_A/fear/M_ikevo_A_fear_9.wav
time:2025-07-16 15:01:58.638+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_A/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_A/happy/M_ikevo_A_happy_9.wav
time:2025-07-16 15:01:58.651+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_A/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_A/normal/M_ikevo_A_normal_3.wav
time:2025-07-16 15:01:58.664+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_A/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_A/relax/M_ikevo_A_relax_7.wav
time:2025-07-16 15:01:58.673+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_A/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_A/sad/M_ikevo_A_sad_10.wav
time:2025-07-16 15:01:58.686+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_ikevo_A/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_ikevo_A/surprise/M_ikevo_A_surprise_3.wav
time:2025-07-16 15:01:58.697+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_actor/angry from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_actor/angry/M_actor_angry_3.wav
time:2025-07-16 15:01:58.709+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_actor/fear from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_actor/fear/M_actor_fear_9.wav
time:2025-07-16 15:01:58.720+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_actor/happy from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_actor/happy/M_actor_happy_9.wav
time:2025-07-16 15:01:58.733+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_actor/normal from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_actor/normal/M_actor_normal_11.wav
time:2025-07-16 15:01:58.740+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_actor/relax from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_actor/relax/M_actor_relax_5.wav
time:2025-07-16 15:01:58.752+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_actor/sad from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_actor/sad/M_actor_sad_12.wav
time:2025-07-16 15:01:58.765+09:00	pid:1	module:__main__	line:214	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loading reference audio: M_actor/surprise from tmp/s3data/lucas-machine-learning-tokyo/trained-model/tts/cosyvoice2/v1/asset/GPT-SoVITS/dataset/M_actor/surprise/M_actor_surprise_3.wav
time:2025-07-16 15:01:58.777+09:00	pid:1	module:__main__	line:225	level:INFO	reqid:e2e-ZwA73Zpg	body:Pre-loaded 133 reference audio files
time:2025-07-16 15:01:58.777+09:00	pid:1	module:utilucas.metrics	line:120	level:INFO	reqid:e2e-ZwA73Zpg	body:elapsed time of load_ref_audios: 1.4791154861450195 sec
text:おはよー、オーナー、元気ー？
time:2025-07-16 15:02:25.208+09:00	pid:1	module:utilucas.metrics	line:120	level:INFO	reqid:e2e-ZwA73Zpg	body:elapsed time of generate_tts_model: 4.5299530029296875e-06 sec
time:2025-07-16 15:02:25.241+09:00	pid:1	module:utilucas.memcache	line:209	level:INFO	reqid:e2e-ZwA73Zpg	body:clear_cache on initialize: <function StructuredConfig._get_value_from_kvs at 0x7eba47413ce0>
time:2025-07-16 15:02:25.241+09:00	pid:1	module:utilucas.memcache	line:83	level:INFO	reqid:e2e-ZwA73Zpg	body:clear cache. func: _get_value_from_kvs
time:2025-07-16 15:02:25.406+09:00	pid:1	module:__main__	line:262	level:INFO	reqid:e2e-ZwA73Zpg	body:CosyVoice2TTS.generate start.
text='おはよー、オーナー、元気ー？'
voice_id='F_natural_B'
emotion_type=<EmotionType.NORMAL: 'normal'>
speed=None
volume=100
pitch=None
voice_style=VoiceStyle(emotion_voice_type=<EmotionVoiceType.NORMAL: 'normal'>, emotion_weight=1.0, voice_speed=100, voice_volume=100, voice_mixing_map={'F_natural_B': 1.0})

/app/.venv/lib/python3.11/site-packages/cosyvoice/cli/model.py:104: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  with self.llm_context, torch.cuda.amp.autocast(self.fp16 is True and hasattr(self.llm, 'vllm') is False):
WARNING 07-16 15:02:26 [preprocess.py:64] Using None for EOS token id because tokenizer is not initialized
INFO 07-16 15:02:26 [metrics.py:417] Avg prompt throughput: 6.7 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.0%, CPU KV cache usage: 0.0%.
/app/.venv/lib/python3.11/site-packages/cosyvoice/cli/model.py:286: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  with torch.cuda.amp.autocast(self.fp16):
output.wav に保存しました
```

</details>

- 実際に生成されたwavはここに掲載できないめ共有していないが、問題なく再生されていることを確認した。

## 実装上の懸念（特にレビューしてほしい部分など）
